### PR TITLE
fix: add missing Fuse import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import './style.css'
 
+import Fuse from 'fuse.js'
+
 const data = require('./data.json')
 
 const NODE_REL = 8


### PR DESCRIPTION
Trying to search for a specific block resulted in the following error: 
```
Uncaught ReferenceError: Fuse is not defined
```
The missing import was added and now the search functionality works

<img width="900" alt="image" src="https://user-images.githubusercontent.com/17057747/219147734-bab2462c-81f0-49c6-8ae1-cb46f4910fa3.png">


